### PR TITLE
Limit allowed concurrency in CI environments

### DIFF
--- a/blueprints/ember-circleci/files/.circleci/config.yml
+++ b/blueprints/ember-circleci/files/.circleci/config.yml
@@ -2,7 +2,7 @@ defaults: &defaults
   docker:
     - image: circleci/node:10-browsers
       environment:
-        JOBS: 2
+        JOBS: 1
   working_directory: ~/<%= name %>
 
 version: 2


### PR DESCRIPTION
The normal mechanism for detecting maximum number of concurrent jobs
does not work properly on CI (where the concurrency is limited to 2 but
available CPU's is a much larger number). This prevents the build from
exhausting resources.

Refs https://github.com/ember-cli/ember-cli/pull/7349