### PR TITLE
Add correction on exam option for blueprints

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,9 +42,6 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: Lint Handlebars
-          command: yarn lint:hbs
-      - run:
           name: Lint JavaScript
           command: yarn lint:js
 
@@ -55,61 +52,7 @@ jobs:
           at: .
       - run:
           name: Run Tests
-          command: npx ember try:one ember-default --skip-cleanup=true
-
-  test_lts_2_18:
-    <<: *defaults
-    steps:
-      - attach_workspace:
-          at: .
-      - run:
-          name: Run Tests Ember LTS 2.18
-          command: npx ember try:one ember-lts-2.18 --skip-cleanup=true
-
-  test_lts_3_4:
-    <<: *defaults
-    steps:
-      - attach_workspace:
-          at: .
-      - run:
-          name: Run Tests Ember LTS 3.4
-          command: npx ember try:one ember-lts-3.4 --skip-cleanup=true
-
-  test_release:
-    <<: *defaults
-    steps:
-      - attach_workspace:
-          at: .
-      - run:
-          name: Run Tests Ember Release
-          command: npx ember try:one ember-release --skip-cleanup=true
-
-  test_beta:
-    <<: *defaults
-    steps:
-      - attach_workspace:
-          at: .
-      - run:
-          name: Run Tests Ember Beta
-          command: npx ember try:one ember-beta --skip-cleanup=true
-
-  test_canary:
-    <<: *defaults
-    steps:
-      - attach_workspace:
-          at: .
-      - run:
-          name: Run Tests Ember Canary
-          command: npx ember try:one ember-canary --skip-cleanup=true
-
-  test_default_with_jquery:
-    <<: *defaults
-    steps:
-      - attach_workspace:
-          at: .
-      - run:
-          name: Run Tests Ember Default With jQuery
-          command: npx ember try:one ember-default-with-jquery --skip-cleanup=true
+          command: yarn test
 
 workflows:
   version: 2
@@ -123,23 +66,5 @@ workflows:
           requires:
             - install_dependencies
       - test:
-          requires:
-            - install_dependencies
-      - test_lts_2_18:
-          requires:
-            - install_dependencies
-      - test_lts_3_4:
-          requires:
-            - install_dependencies
-      - test_release:
-          requires:
-            - install_dependencies
-      - test_beta:
-          requires:
-            - install_dependencies
-      - test_canary:
-          requires:
-            - install_dependencies
-      - test_default_with_jquery:
           requires:
             - install_dependencies

--- a/blueprints/ember-circleci/files/.circleci/config.yml
+++ b/blueprints/ember-circleci/files/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
 
   test:
     <<: *defaults
-<% if (exam) { %>    parallelism: <%= parallel %>
+<% if (addon && exam) { %>    parallelism: <%= parallel %>
 <% } %>    steps:
       - attach_workspace:
           at: .
@@ -63,7 +63,7 @@ jobs:
 <% if (addon) { %>
   test_lts_2_18:
     <<: *defaults
-<% if (exam) { %>    parallelism: <%= parallel %>
+<% if (addon && exam) { %>    parallelism: <%= parallel %>
 <% } %>    steps:
       - attach_workspace:
           at: .
@@ -73,7 +73,7 @@ jobs:
 
   test_lts_3_4:
     <<: *defaults
-<% if (exam) { %>    parallelism: <%= parallel %>
+<% if (addon && exam) { %>    parallelism: <%= parallel %>
 <% } %>    steps:
       - attach_workspace:
           at: .
@@ -83,7 +83,7 @@ jobs:
 
   test_release:
     <<: *defaults
-<% if (exam) { %>    parallelism: <%= parallel %>
+<% if (addon && exam) { %>    parallelism: <%= parallel %>
 <% } %>    steps:
       - attach_workspace:
           at: .
@@ -93,7 +93,7 @@ jobs:
 
   test_beta:
     <<: *defaults
-<% if (exam) { %>    parallelism: <%= parallel %>
+<% if (addon && exam) { %>    parallelism: <%= parallel %>
 <% } %>    steps:
       - attach_workspace:
           at: .
@@ -103,7 +103,7 @@ jobs:
 
   test_canary:
     <<: *defaults
-<% if (exam) { %>    parallelism: <%= parallel %>
+<% if (addon && exam) { %>    parallelism: <%= parallel %>
 <% } %>    steps:
       - attach_workspace:
           at: .
@@ -113,7 +113,7 @@ jobs:
 
   test_default_with_jquery:
     <<: *defaults
-<% if (exam) { %>    parallelism: <%= parallel %>
+<% if (addon && exam) { %>    parallelism: <%= parallel %>
 <% } %>    steps:
       - attach_workspace:
           at: .

--- a/blueprints/ember-circleci/index.js
+++ b/blueprints/ember-circleci/index.js
@@ -11,17 +11,23 @@ module.exports = {
 
   normalizeEntityName() {},
 
-  locals({ exam, project }) {
-    let { name, keywords = [] } = project.pkg;
+  locals(options) {
+    let {
+      exam,
+      project: {
+        root,
+        pkg: { name, keywords = [] }
+      }
+    } = options;
     isAddon = keywords.includes("ember-addon");
-    let hasYarn = existsSync(path.join(project.root, "yarn.lock"));
+    let hasYarn = existsSync(path.join(root, "yarn.lock"));
     hasExam = exam !== undefined;
     return {
       name: stringUtil.dasherize(name),
       yarn: hasYarn,
       addon: isAddon,
       exam: hasExam,
-      parallel: exam ? exam : 4
+      parallel: !isNaN(Number.parseInt(exam)) ? exam : 4
     };
   },
 
@@ -34,8 +40,8 @@ module.exports = {
   },
 
   afterInstall() {
-    if (hasExam) {
-      //return this.addPackagesToProject([{ name: "ember-exam" }]);
+    if (isAddon && hasExam) {
+      return this.addPackageToProject("ember-exam");
     }
   }
 };

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "ember-cli-template-lint": "^1.0.0-beta.1",
     "ember-cli-uglify": "^2.1.0",
     "ember-disable-prototype-extensions": "^1.1.3",
-    "ember-exam": "^3.0.1",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.1.0",
     "ember-maybe-import-regenerator": "^0.1.6",

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,7 +1,7 @@
 import Application from "../app";
 import config from "../config/environment";
 import { setApplication } from "@ember/test-helpers";
-import start from "ember-exam/test-support/start";
+import { start } from "ember-qunit";
 
 setApplication(Application.create(config.APP));
 

--- a/tests/unit/utils/ember-observer-test.js
+++ b/tests/unit/utils/ember-observer-test.js
@@ -1,0 +1,7 @@
+import { module, test } from "qunit";
+
+module("Unit | Utility | ember-observer", function() {
+  test("it works", function(assert) {
+    assert.ok(true);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3135,7 +3135,7 @@ ember-cli-babel@^7.1.2:
     ensure-posix-path "^1.0.2"
     semver "^5.5.0"
 
-ember-cli-babel@^7.4.2, ember-cli-babel@^7.7.3:
+ember-cli-babel@^7.4.2:
   version "7.7.3"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.7.3.tgz#f94709f6727583d18685ca6773a995877b87b8a0"
   integrity sha512-/LWwyKIoSlZQ7k52P+6agC7AhcOBqPJ5C2u27qXHVVxKvCtg6ahNuRk/KmfZmV4zkuw4EjTZxfJE1PzpFyHkXg==
@@ -3427,22 +3427,6 @@ ember-disable-prototype-extensions@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/ember-disable-prototype-extensions/-/ember-disable-prototype-extensions-1.1.3.tgz#1969135217654b5e278f9fe2d9d4e49b5720329e"
   integrity sha1-GWkTUhdlS14nj5/i2dTkm1cgMp4=
-
-ember-exam@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/ember-exam/-/ember-exam-3.0.1.tgz#a4b19aeef44224b4e681ac4e69bd3fceffa9a912"
-  integrity sha512-raI5H9cG9C1VZP6hH88ZCgI8uBJh5FDMTeUdz54slRwFWu0OCIPTbyqjuWefJbSAVqUt57hWH1dvgv8XsF8gFQ==
-  dependencies:
-    chalk "^2.1.0"
-    cli-table3 "^0.5.1"
-    debug "^4.1.0"
-    ember-cli-babel "^7.7.3"
-    execa "^1.0.0"
-    fs-extra "^7.0.1"
-    js-yaml "^3.13.1"
-    rimraf "^2.6.2"
-    semver "^6.0.0"
-    silent-error "^1.1.1"
 
 ember-export-application-global@^2.0.0:
   version "2.0.0"
@@ -5155,7 +5139,7 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-js-yaml@^3.12.2, js-yaml@^3.13.1:
+js-yaml@^3.12.2:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
@@ -7125,11 +7109,6 @@ semver@^5.5.1, semver@^5.6.0:
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
   integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
-
-semver@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-6.0.0.tgz#05e359ee571e5ad7ed641a6eec1e547ba52dea65"
-  integrity sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ==
 
 send@0.16.2:
   version "0.16.2"


### PR DESCRIPTION
- Always check that this is an addon before activate exam option
- Don't forget to install ember-exam if the option is activated
- Remove ember-exam of dev deps and simplify CircleCI config of this addon to run what is really needed
- Add one fake test (waiting for #17 to add real tests)
