### PR TITLE
fix: test-helper by checking exam option

### DIFF
--- a/blueprints/ember-circleci/files/tests/test-helper.js
+++ b/blueprints/ember-circleci/files/tests/test-helper.js
@@ -1,8 +1,9 @@
 import Application from "../app";
 import config from "../config/environment";
 import { setApplication } from "@ember/test-helpers";
-import start from "ember-exam/test-support/start";
-
+<% if (exam) { %>import start from "ember-exam/test-support/start";
+<% } else { %>import { start } from "ember-qunit";
+<% } %>
 setApplication(Application.create(config.APP));
 
 start();


### PR DESCRIPTION
Before the fix, `tests/test-helper.js` file was always overriden to be compatible with exam and broken your build if you don't use exam...