### PR TITLE
Config.yml file should use the `command` action rather than `run` if exam===false

### DIFF
--- a/blueprints/ember-circleci/files/.circleci/config.yml
+++ b/blueprints/ember-circleci/files/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - checkout
 <% if (exam === false) { %>      - run:
           name: Generate reports folder
-          run: mkdir -p ./reports
+          command: mkdir -p ./reports
 <% } %>      - persist_to_workspace:
           root: .
           paths:


### PR DESCRIPTION
When initiating the creation of a config.yml file, if no `--exam` param is passed, current code creates a run step that should have a name/command pair. Instead it has a name/run pair, which fails in CircleCI.