### PR TITLE
fix: increase testem browser timeout

### DIFF
--- a/blueprints/ember-circleci/files/testem.js
+++ b/blueprints/ember-circleci/files/testem.js
@@ -5,8 +5,13 @@ module.exports = {<% if (exam) { %>
   parallel: -1,<% } %>
   test_page: `tests/index.html?${testParams}`,
   disable_watching: true,
-  launch_in_ci: ['Chrome'],
-  launch_in_dev: ['Chrome'],
+  launch_in_ci: [
+    'Chrome'
+  ],
+  launch_in_dev: [
+    'Chrome'
+  ],
+  browser_start_timeout: 120,
   browser_args: {
     Chrome: {
       ci: [

--- a/testem.js
+++ b/testem.js
@@ -7,6 +7,7 @@ module.exports = {
   disable_watching: true,
   launch_in_ci: ["Chrome"],
   launch_in_dev: ["Chrome"],
+  browser_start_timeout: 120,
   browser_args: {
     Chrome: {
       ci: [


### PR DESCRIPTION
Following https://github.com/ember-cli/ember-cli/commit/83d1aaea5e3db76631e1b27f21a3fcc6beca82a4

Some CI systems seem to hit the default limit much more often than others.

Let's use the default config from ember-cli to avoid diff confusion for nothing