### PR TITLE
ci: remove key `working_directory`

### DIFF
--- a/blueprints/ember-circleci/files/.circleci/config.yml
+++ b/blueprints/ember-circleci/files/.circleci/config.yml
@@ -3,7 +3,6 @@ defaults: &defaults
     - image: circleci/node:10-browsers
       environment:
         JOBS: 1
-  working_directory: ~/project
 
 orbs:
   node: circleci/node@2.1.1


### PR DESCRIPTION
Remove key `working_directory` in the job `defaults`.

The key is declared but uses its default value `~/project`.
https://circleci.com/docs/2.0/configuration-reference/#job_name