### PR TITLE
Re-use prebuilt assets with a parallelized build to improve performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This addon generates the `.circleci/config.yml` file.
 Lint and Tests jobs are started as parallel jobs.
 
 If you activate ember-exam, it provides the ability to split, parallelize, and load-balance your test suite.
+For an app, built assets will build once and then be re-used during parallelization to further speed up builds.
 
 If ember-exam is not activated, it provides reports of the tests by using xUnit.
 xUnit generates an xml file and expose it to CircleCI, that way it can gave a quick overview of the failing tests

--- a/blueprints/ember-circleci/files/.circleci/config.yml
+++ b/blueprints/ember-circleci/files/.circleci/config.yml
@@ -19,7 +19,10 @@ jobs:
           cache-key: "yarn.lock"<% } %>
           cache-version: "v1"
           include-branch-in-cache-key: false
-<% if (exam === false) { %>      - run:
+<% if (exam && !addon) { %>      - run:
+          name: Prebuild Ember app for tests
+          command: yarn ember build --environment=testing
+<% } else { %>      - run:
           name: Generate reports folder
           command: mkdir reports
 <% } %>      - persist_to_workspace:
@@ -63,7 +66,7 @@ if (exam) { %>    parallelism: <%= parallel %>
           at: .
       - run:
           name: Run <% if (addon) { %><< parameters.scenario >> <% } %>Tests
-          command: <% if (addon) { if (yarn) { %>yarn<% } else { %>npx<% } %> ember try:one ember-<< parameters.scenario >> --skip-cleanup=true<% } else if (exam) { if (yarn) { %>yarn<% } else { %>npx<% } %> ember exam --split=$CIRCLE_NODE_TOTAL --partition=`expr $CIRCLE_NODE_INDEX + 1` --parallel --load-balance<% } else if (yarn) { %>yarn test:ember<% } else { %>npm run test:ember<% } %>
+          command: <% if (addon) { if (yarn) { %>yarn<% } else { %>npx<% } %> ember try:one ember-<< parameters.scenario >> --skip-cleanup=true<% } else if (exam) { if (yarn) { %>yarn<% } else { %>npx<% } %> ember exam --path=dist --split=$CIRCLE_NODE_TOTAL --partition=`expr $CIRCLE_NODE_INDEX + 1` --parallel --load-balance<% } else if (yarn) { %>yarn test:ember<% } else { %>npm run test:ember<% } %>
 <% if (exam === false) { %>      - store_test_results:
           path: "reports"
       - store_artifacts:


### PR DESCRIPTION
Started using your addon for a client app recently with Ember Exam and parallelization. Thanks for the work you've put in here! 💛 

For this particular app, build times are a bit slow. That made it noticeable when the work was split into multiple jobs that the build was being run each time. I remembered a conversation I had a few years ago with some of the other Ember core team folks about the ability to re-use built assets for tests (https://twitter.com/real_ate/status/1029740124928651264). Using the built assets by providing a `--path=dist` is working quite nicely, so thought it'd be worth upstreaming back into this blueprint.

In theory this might work with an addon workflow and ember-try as well, but I haven't tested that.

Let me know what you think!